### PR TITLE
Fix role value for incident professor

### DIFF
--- a/usaer_system/incidencias/forms.py
+++ b/usaer_system/incidencias/forms.py
@@ -18,10 +18,10 @@ class IncidenciaForm(forms.ModelForm):
         # Filtro dinámico si se pasa escuela
         if escuela:
             self.fields['profesor'].queryset = User.objects.filter(
-                escuela=escuela, role='Profesor'
+                escuela=escuela, role='MAESTRO_APOYO'
             )
         else:
-            self.fields['profesor'].queryset = User.objects.filter(role='Profesor')
+            self.fields['profesor'].queryset = User.objects.filter(role='MAESTRO_APOYO')
 
         # Configuración de Crispy
         self.helper = FormHelper()

--- a/usaer_system/incidencias/migrations/0003_alter_incidencia_profesor.py
+++ b/usaer_system/incidencias/migrations/0003_alter_incidencia_profesor.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('incidencias', '0002_alter_incidencia_profesor'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='incidencia',
+            name='profesor',
+            field=models.ForeignKey(
+                limit_choices_to={'role': 'MAESTRO_APOYO'},
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='incidencias_reportadas',
+                to=settings.AUTH_USER_MODEL,
+                verbose_name='Profesor reportado'
+            ),
+        ),
+    ]

--- a/usaer_system/incidencias/models.py
+++ b/usaer_system/incidencias/models.py
@@ -20,7 +20,7 @@ class Incidencia(models.Model):
     )
     profesor = models.ForeignKey(
         settings.AUTH_USER_MODEL,
-        limit_choices_to={'role': 'Profesor'},
+        limit_choices_to={'role': 'MAESTRO_APOYO'},
         on_delete=models.SET_NULL,
         null=True,
         verbose_name="Profesor reportado",

--- a/usaer_system/incidencias/views.py
+++ b/usaer_system/incidencias/views.py
@@ -42,7 +42,7 @@ def crear_incidencia(request):
 
 
 @login_required
-@roles_permitidos(['DOCENTE', 'MAESTRO_APOYO', 'ADMIN'])
+@roles_permitidos(['MAESTRO_APOYO', 'ADMIN'])
 def listar_incidencias(request):
     """
     Muestra al docente, maestro de apoyo o admin solo sus incidencias
@@ -99,7 +99,7 @@ def revisar_incidencias(request):
 
     profesores = User.objects.filter(
         escuela=request.user.escuela,
-        role='DOCENTE'
+        role='MAESTRO_APOYO'
     ).only('id', 'first_name', 'last_name')
 
     return render(request, 'incidencias/revisar.html', {


### PR DESCRIPTION
## Summary
- use `MAESTRO_APOYO` for incident professor role
- adjust querysets that filtered by the old role name
- add migration to update `limit_choices_to`

## Testing
- `python usaer_system/manage.py makemigrations incidencias` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ad84d1e8c8326884051ecb86f6050