### PR TITLE
Fix missing reverse import

### DIFF
--- a/usaer_system/asistencias/admin.py
+++ b/usaer_system/asistencias/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 from django.utils.html import format_html
+from django.urls import reverse
 from .models import Asistencia
 
 class PresenteFilter(admin.SimpleListFilter):


### PR DESCRIPTION
## Summary
- add missing `reverse` import in asistencias admin

## Testing
- `python -m py_compile usaer_system/asistencias/admin.py`
- `python usaer_system/manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ad85705e483268ae82e67fe20ea74