### PR TITLE
Add success messages to remaining views

### DIFF
--- a/usaer_system/alumnos/views.py
+++ b/usaer_system/alumnos/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import HttpResponse
+from django.contrib import messages
 import csv
 
 from .models import Alumno, Escuela
@@ -64,6 +65,7 @@ def crear_alumno(request):
             obj.escuela_id = request.POST.get('escuela')
             obj.grado      = request.POST.get('grado')
             obj.save()
+            messages.success(request, "Alumno creado correctamente.")
             return redirect('alumnos:listar_alumnos')
     else:
         form = AlumnoForm()
@@ -94,6 +96,7 @@ def editar_alumno(request, pk):
             obj.escuela_id = request.POST.get('escuela')
             obj.grado      = request.POST.get('grado')
             obj.save()
+            messages.success(request, "Alumno actualizado correctamente.")
             return redirect('alumnos:listar_alumnos')
     else:
         form = AlumnoForm(instance=alumno)
@@ -108,6 +111,7 @@ def eliminar_alumno(request, pk):
     alumno = get_object_or_404(Alumno, pk=pk)
     if request.method == 'POST':
         alumno.delete()
+        messages.success(request, "Alumno eliminado correctamente.")
         return redirect('alumnos:listar_alumnos')
     return render(request, 'alumnos/confirmar_eliminar.html', {
         'alumno': alumno

--- a/usaer_system/calendario/views.py
+++ b/usaer_system/calendario/views.py
@@ -2,6 +2,7 @@ from django.views.generic import ListView, CreateView, UpdateView, DeleteView, D
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse_lazy
 from django.http import HttpResponseForbidden
+from django.contrib import messages
 from .models import EventoCalendario
 from .forms import EventoForm
 from django.db import models
@@ -37,6 +38,7 @@ class EventoCreateView(LoginRequiredMixin, CreateView):
         # Si no es admin o secretario, forzar tipo PERSONAL
         if not (self.request.user.is_staff or getattr(self.request.user, 'rol', '') == 'SECRETARIO'):
             form.instance.tipo = 'PERSONAL'
+        messages.success(self.request, "Evento creado correctamente.")
         return super().form_valid(form)
 
 # ✅ 3. Editar evento (solo si el usuario lo creó o es institucional con permiso)
@@ -50,6 +52,10 @@ class EventoUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         kwargs = super().get_form_kwargs()
         kwargs["user"] = self.request.user
         return kwargs
+
+    def form_valid(self, form):
+        messages.success(self.request, "Evento actualizado correctamente.")
+        return super().form_valid(form)
 
     def test_func(self):
         evento = self.get_object()
@@ -71,6 +77,10 @@ class EventoDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
         return evento.creado_por == user or (
             evento.tipo == 'INSTITUCIONAL' and (user.is_staff or getattr(user, 'rol', '') == 'SECRETARIO')
         )
+
+    def delete(self, request, *args, **kwargs):
+        messages.success(request, "Evento eliminado correctamente.")
+        return super().delete(request, *args, **kwargs)
 
 # ✅ 5. Detalle del evento
 class EventoDetailView(LoginRequiredMixin, DetailView):

--- a/usaer_system/documentos/views.py
+++ b/usaer_system/documentos/views.py
@@ -238,3 +238,7 @@ class ExpedienteDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
             return redirect('documentos:lista_expedientes')
 
         return super().dispatch(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        messages.success(request, "Expediente eliminado correctamente.")
+        return super().delete(request, *args, **kwargs)

--- a/usaer_system/incidencias/views.py
+++ b/usaer_system/incidencias/views.py
@@ -138,6 +138,8 @@ def editar_incidencia(request, pk):
                     messages.info(request, f"Estado actualizado a {incidencia.get_estado_display()}")
             if 'respuesta_admin' in form.changed_data:
                 messages.info(request, "Comentarios de dirección actualizados")
+            if not {'estado', 'respuesta_admin'} & set(form.changed_data):
+                messages.success(request, "Incidencia actualizada correctamente.")
             return redirect('incidencias:revisar_incidencias')
     else:
         form = IncidenciaForm(instance=incidencia, escuela=request.user.escuela)

--- a/usaer_system/oficios/views.py
+++ b/usaer_system/oficios/views.py
@@ -2,6 +2,7 @@ import os
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
+from django.contrib import messages
 from .models import Oficio
 from .forms import OficioForm
 
@@ -18,6 +19,7 @@ def subir_oficio(request):
             oficio = form.save(commit=False)
             oficio.subido_por = request.user
             oficio.save()
+            messages.success(request, "Oficio subido correctamente.")
             return redirect('oficios:lista_oficios')
     else:
         form = OficioForm()
@@ -38,6 +40,7 @@ def editar_oficio(request, pk):
                 if oficio.archivo.storage.exists(archivo_anterior):
                     oficio.archivo.storage.delete(archivo_anterior)
             form.save()
+            messages.success(request, "Oficio actualizado correctamente.")
             return redirect('oficios:lista_oficios')
     else:
         form = OficioForm(instance=oficio)
@@ -49,5 +52,6 @@ def eliminar_oficio(request, pk):
     oficio = get_object_or_404(Oficio, pk=pk)
     if request.method == 'POST':
         oficio.delete()
+        messages.success(request, "Oficio eliminado correctamente.")
         return redirect('oficios:lista_oficios')
     return render(request, 'oficios/confirmar_eliminacion.html', {'oficio': oficio})

--- a/usaer_system/rac/views.py
+++ b/usaer_system/rac/views.py
@@ -8,6 +8,7 @@ from django import forms
 from django.urls import reverse_lazy
 from django.views.generic import ListView, CreateView, UpdateView, View
 from django.http import HttpResponse
+from django.contrib import messages
 
 from .models import RegistroRAC
 from .forms import RegistroRACForm
@@ -72,6 +73,10 @@ class RegistroRACCreateView(CreateView):
         ctx['escuelas_data'] = json.dumps(escuelas)
         return ctx
 
+    def form_valid(self, form):
+        messages.success(self.request, "Registro RAC creado correctamente.")
+        return super().form_valid(form)
+
 
 class RegistroRACUpdateView(RegistroRACCreateView, UpdateView):
     """
@@ -87,6 +92,10 @@ class RegistroRACUpdateView(RegistroRACCreateView, UpdateView):
             qs = qs | Alumno.objects.filter(pk=self.object.alumno.pk)
             form.fields['alumno'].queryset = qs
         return form
+
+    def form_valid(self, form):
+        messages.success(self.request, "Registro RAC actualizado correctamente.")
+        return super().form_valid(form)
 
 
 class ExportRACExcelView(View):


### PR DESCRIPTION
## Summary
- ensure incidence edits show a success notification
- keep success messages across CRUD operations in all apps

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python usaer_system/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ddd8f89888326b9ad8a864c82fa59